### PR TITLE
fix: handle bool values in liveForm enum fields

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -12,6 +12,24 @@ from typing import Annotated, Any, Dict, List, Optional, Union
 from pydantic import BaseModel, Field
 
 
+class BooleanStringEnum(Enum):
+    """Base class for enums with 'true'/'false' string members.
+
+    Automatically coerces Python booleans to their string equivalents
+    so Pydantic validation succeeds regardless of whether the API returns
+    a JSON boolean (true/false) or a JSON string ("true"/"false").
+    """
+    @classmethod
+    def _missing_(cls, value):
+        if isinstance(value, bool):
+            return cls('true') if value else cls('false')
+        if isinstance(value, str):
+            lower = value.strip().lower()
+            if lower in ('true', 'false'):
+                return cls(lower)
+        return None
+
+
 class Language(Enum):
     C_ = 'C#'
     Py = 'Py'
@@ -1703,17 +1721,17 @@ class LiveAuthenticationData(BaseModel):
     pass
 
 
-class NotifyInsights(Enum):
+class NotifyInsights(BooleanStringEnum):
     true = 'true'
     false = 'false'
 
 
-class NotifyOrderEvents(Enum):
+class NotifyOrderEvents(BooleanStringEnum):
     true = 'true'
     false = 'false'
 
 
-class AutoRestart(Enum):
+class AutoRestart(BooleanStringEnum):
     true = 'true'
     false = 'false'
 

--- a/src/models.py
+++ b/src/models.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from pydantic import RootModel, ConfigDict
 
 from datetime import datetime, time
+datetime = str  # QC API returns non-ISO datetime strings; avoid format: date-time in JSON schema
 from enum import Enum
 from typing import Annotated, Any, Dict, List, Optional, Union
 
@@ -2186,8 +2187,8 @@ class OrderSubmissionData(BaseModel):
     ] = None
 
 
-class ParameterSet1(BaseModel):
-    RootModel: Annotated[List, Field(max_items=0)]
+class ParameterSet1(RootModel):
+    root: Any = None
 
 
 class Holding(BaseModel):


### PR DESCRIPTION
Fixes 3 bugs in models.py that break response validation across 10+ MCP methods:

Bool/string enum mismatch — QC API returns True/False (Python bools) for fields like notifyInsights, but Pydantic expects "true"/"false" (strings). Adds BooleanStringEnum base class that handles coercion automatically.

Datetime format too strict — QC API returns datetimes like "2024-01-15 10:30:00" but the schema requires ISO 8601 ("2024-01-15T10:30:00Z"). Breaks list_projects, read_file, list_backtests, read_backtest, read_live_algorithm, and more. Fixed by relaxing the type constraint.

ParameterSet1 rejects valid data — Defined with max_items=0, rejecting any backtest response with parameters. Fixed by converting to a flexible RootModel.